### PR TITLE
Add element site menu to node editor HUD

### DIFF
--- a/src/templates/navs/_editor.html
+++ b/src/templates/navs/_editor.html
@@ -65,6 +65,7 @@
         elements: [element],
         elementType: node.type,
         sources: '*',
+        showSiteMenu: 1,
         limit: 1,
         modalStorageKey: 'navigation.elementId',
     }) }}


### PR DESCRIPTION
Currently, when you edit an existing node to change the element it is linked to, the element selector modal only shows entries from the default site and doesn't show the site selector menu. The proposed change adds the site selector menu to the element selector modal, so the functionality matches the situation when you create a new node from scratch, where you are able to choose an entry from all sites in a multi-site installation.